### PR TITLE
Remove the backed in dependency on the bootstrap-3 package.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Set up a simple admin page
 ```sh
 $ mrt create app
 $ cd app
+$ mrt add bootstrap-3		# or mrt add less-bootstrap-3
 $ mrt add accounts-password
 $ mrt add roles
 $ mrt add accounts-ui-bootstrap-3

--- a/package.js
+++ b/package.js
@@ -4,7 +4,6 @@ Package.describe({
 
 Package.on_use(function (api, where) {
 	api.use('standard-app-packages', ['client', 'server']);
-	api.use('bootstrap-3', 'client');
 	api.use('roles', ['client', 'server']);
 
 	api.add_files('libs/user_query.js', ['client', 'server']);

--- a/smart.json
+++ b/smart.json
@@ -6,7 +6,6 @@
 	"version": "0.2.5",
 	"git": "https://github.com/hharnisc/meteor-accounts-admin-ui-bootstrap-3.git",
 	"packages": {
-		"bootstrap-3": "3.1.1-1",
 		"roles": "1.2.8"
 	}
 }


### PR DESCRIPTION
The hardcoded dependency on the 'bootstrap-3' package makes it problematic
for users who use other packages that create the bootstrap-3 files -- such
as the less-bootstrap-3 package.
